### PR TITLE
Update project configuration to resolve linking warning in app extension

### DIFF
--- a/DeepDiff.xcodeproj/project.pbxproj
+++ b/DeepDiff.xcodeproj/project.pbxproj
@@ -963,6 +963,7 @@
 		D5B2E8B41C3A780C00C0327D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -984,6 +985,7 @@
 		D5B2E8B51C3A780C00C0327D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Since the framework doesn't actually use any API that's prohibited in app extension, this PR modified project configuration to resolve the linking warning when linked in app extension.