### PR TITLE
Migrate to swift 4.2

### DIFF
--- a/DeepDiff.podspec
+++ b/DeepDiff.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "DeepDiff"
   s.summary          = "Diff in Swift"
-  s.version          = "1.2.0"
+  s.version          = "1.3.0"
   s.homepage         = "https://github.com/onmyway133/DeepDiff"
   s.license          = 'MIT'
   s.author           = { "Khoa Pham" => "onmyway133@gmail.com" }
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
 
   s.ios.framework  = "UIKit"
 
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.1' }
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
 end

--- a/DeepDiff.xcodeproj/project.pbxproj
+++ b/DeepDiff.xcodeproj/project.pbxproj
@@ -463,11 +463,11 @@
 					};
 					D5B2E89E1C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1000;
 					};
 					D5B2E8A81C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1000;
 					};
 					D5C6293F1C3A7FAA007F7B7C = {
 						CreatedOnToolsVersion = 7.2;
@@ -703,7 +703,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
@@ -732,7 +732,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
@@ -757,7 +757,7 @@
 				SDKROOT = appletvos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
@@ -780,7 +780,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.DeepDiff-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
@@ -812,7 +812,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
@@ -842,7 +842,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
@@ -978,7 +978,7 @@
 				PRODUCT_NAME = DeepDiff;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -999,7 +999,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fantageek.DeepDiff-iOS";
 				PRODUCT_NAME = DeepDiff;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -1014,7 +1014,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.DeepDiffTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -1028,7 +1028,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.DeepDiffTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -1052,6 +1052,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -1074,6 +1075,7 @@
 				PRODUCT_NAME = DeepDiff;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -1090,6 +1092,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.DeepDiff-MacTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -1106,6 +1109,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.DeepDiff-MacTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Sources/iOS/UITableView+Extensions.swift
+++ b/Sources/iOS/UITableView+Extensions.swift
@@ -22,9 +22,9 @@ public extension UITableView {
   public func reload<T: Hashable>(
     changes: [Change<T>],
     section: Int = 0,
-    insertionAnimation: UITableViewRowAnimation = .automatic,
-    deletionAnimation: UITableViewRowAnimation = .automatic,
-    replacementAnimation: UITableViewRowAnimation = .automatic,
+    insertionAnimation: UITableView.RowAnimation = .automatic,
+    deletionAnimation: UITableView.RowAnimation = .automatic,
+    replacementAnimation: UITableView.RowAnimation = .automatic,
     completion: ((Bool) -> Void)? = nil) {
     
     let changesWithIndexPath = IndexPathConverter().convert(changes: changes, section: section)
@@ -61,8 +61,8 @@ public extension UITableView {
   // MARK: - Helper
   
   private func internalBatchUpdates(changesWithIndexPath: ChangeWithIndexPath,
-                                    insertionAnimation: UITableViewRowAnimation,
-                                    deletionAnimation: UITableViewRowAnimation) {
+                                    insertionAnimation: UITableView.RowAnimation,
+                                    deletionAnimation: UITableView.RowAnimation) {
     changesWithIndexPath.deletes.executeIfPresent {
       deleteRows(at: $0, with: deletionAnimation)
     }


### PR DESCRIPTION
Here is migration to swift 4.2.
It is important not to forget to add tag `1.3.0` and push it to pod specs.