### PR TITLE
Make diffId Hashable, rather than Int

### DIFF
--- a/Sources/Shared/Algorithms/Heckel.swift
+++ b/Sources/Shared/Algorithms/Heckel.swift
@@ -69,7 +69,7 @@ public final class Heckel<T: DiffAware> {
   public func diff(old: [T], new: [T]) -> [Change<T>] {
     // The Symbol Table
     // Each line works as the key in the table look-up, i.e. as table[line].
-    var table: [Int: TableEntry] = [:]
+    var table: [T.DiffId: TableEntry] = [:]
 
     // The arrays OA and NA have one entry for each line in their respective files, O and N
     var oldArray = [ArrayEntry]()
@@ -84,7 +84,7 @@ public final class Heckel<T: DiffAware> {
 
   private func perform1stPass(
     new: [T],
-    table: inout [Int: TableEntry],
+    table: inout [T.DiffId: TableEntry],
     newArray: inout [ArrayEntry]) {
 
     // 1st pass
@@ -106,7 +106,7 @@ public final class Heckel<T: DiffAware> {
 
   private func perform2ndPass(
     old: [T],
-    table: inout [Int: TableEntry],
+    table: inout [T.DiffId: TableEntry],
     oldArray: inout [ArrayEntry]) {
 
     // 2nd pass

--- a/Sources/Shared/DiffAware.swift
+++ b/Sources/Shared/DiffAware.swift
@@ -12,7 +12,9 @@ import Foundation
 /// diffId: Each object must be uniquely identified by id. This is to tell if there is deletion or insertion
 /// compareContent: An object can change some properties but having its id intact. This is to tell if there is replacement
 public protocol DiffAware {
-  var diffId: Int { get }
+  associatedtype DiffId: Hashable
+
+  var diffId: DiffId { get }
   static func compareContent(_ a: Self, _ b: Self) -> Bool
 }
 


### PR DESCRIPTION
The requirement that diffId is `Int` means that I have to hash my input value, only to have it re-hashed when used internally as a dictionary key. I don't think it really adds much complexity to require instead that diffId is `Hashable`. I don't think it too likely to have to constrain the type in client code, in practice, so it shouldn't add much cognitive or code overhead.

This was already discussed in https://github.com/onmyway133/DeepDiff/pull/28/files#r259297434 but left as Int, for simplicity.