### PR TITLE
Swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,13 +1,19 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
 let package = Package(
     name: "DeepDiff",
+    platforms: [
+        .macOS(.v10_11),
+        .iOS(.v8),
+        .tvOS(.v11),
+        .watchOS(.v3)
+    ],
     products: [
-        .library(name: "DeepDiff", targets: ["DeepDiff"])
+        .library(name: "DeepDiff", targets: ["DeepDiff"]),
     ],
     targets: [
-        .target( name: "DeepDiff", dependencies: [])
+        .target(name: "DeepDiff", path: "Sources")
     ]
 )

--- a/Sources/iOS/IndexPathConverter.swift
+++ b/Sources/iOS/IndexPathConverter.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 Khoa Pham. All rights reserved.
 //
 
+#if os(iOS) || os(tvOS)
 import Foundation
 
 public struct ChangeWithIndexPath {
@@ -58,3 +59,4 @@ extension Int {
     return IndexPath(item: self, section: section)
   }
 }
+#endif

--- a/Sources/iOS/UICollectionView+Extensions.swift
+++ b/Sources/iOS/UICollectionView+Extensions.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 Khoa Pham. All rights reserved.
 //
 
+#if os(iOS) || os(tvOS)
 import UIKit
 
 public extension UICollectionView {
@@ -60,4 +61,4 @@ public extension UICollectionView {
     }
   }
 }
-
+#endif

--- a/Sources/iOS/UITableView+Extensions.swift
+++ b/Sources/iOS/UITableView+Extensions.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 Khoa Pham. All rights reserved.
 //
 
+#if os(iOS) || os(tvOS)
 import UIKit
 
 public extension UITableView {
@@ -91,3 +92,4 @@ public extension UITableView {
     }
   }
 }
+#endif


### PR DESCRIPTION
Added conditional compilation for iOS and tvOS since Swift packages don't support overlapping sources between build targets (makes separate targets for the four platforms impossible).

The minimum platform version requirements reflect the build targets in DeepDiff's current xcodeproj.