### PR TITLE
Removing DeepDiff prefix in preprocess function invocation in WagnerF…

### DIFF
--- a/Sources/Shared/Algorithms/WagnerFischer.swift
+++ b/Sources/Shared/Algorithms/WagnerFischer.swift
@@ -22,7 +22,7 @@ public final class WagnerFischer<T: DiffAware> {
     previousRow.seed(with: new)
     let currentRow = Row<T>()
 
-    if let changes = DeepDiff.preprocess(old: old, new: new) {
+    if let changes = preprocess(old: old, new: new) {
       return changes
     }
 


### PR DESCRIPTION
…ischer algorithm

I could not build tvOS scheme using carthage. I started looking for an error and found out DeepDiff is referenced from inside Wagner algorithm where files are put into same module that makes the DeepDiff module.

By removing the prefix to static func from DeepDiff.swift file it compiles fine. 

Try building SwiftPackage-TvOS scheme locally on 5.1 and error pops up instantly. Hope it helps
